### PR TITLE
Restructure OFS PIM Avalon memory interface.

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/README.md
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/README.md
@@ -1,0 +1,21 @@
+# Base Interface Classes #
+
+This tree holds generic definitions of standard interfaces, often with
+embedded debug logging for simulation. The interfaces may be instantiated in
+multiple contexts. For example, an Avalon interface may be used either for
+local memory and for host channels.
+
+Generic modules, such as clock crossing bridges, may also be present.
+
+## Port Naming ##
+
+Ports are typically named for the direction of the endpoint to which they
+connect, e.g.: "to_master" and "to_slave". This seems unnecessarily
+complicated for simple cases such as a master connected directly to a
+slave. Consider, however, the naming of ports inside a shim that has two
+ports: one in the direction of the master and one in the direction of the
+slave. The shim's "slave" port would be on the master side and the shim's
+"master" port would be on the slave side.  With "to_" naming, a shim's
+"to_master" connects to the master. The endpoints are also consistent: the
+master's outgoing port is named "to_slave" and the slave's outgoing port is
+named "to_master".

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.sv
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2019, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -30,17 +30,21 @@
 
 `include "ofs_plat_if.vh"
 
-interface ofs_plat_local_mem_avalon_if
+//
+// Generic description of an Avalon memory interface.
+//
+
+interface ofs_plat_avalon_mem_if
   #(
     // Log events for this instance?
     parameter ofs_plat_log_pkg::t_log_class LOG_CLASS = ofs_plat_log_pkg::NONE,
 
-    // Controls the size of bank_number
-    parameter NUM_BANKS = 1,
+    // Controls the size of instance_number
+    parameter NUM_INSTANCES = 1,
 
-    parameter ADDR_WIDTH = local_mem_cfg_pkg::LOCAL_MEM_ADDR_WIDTH,
-    parameter DATA_WIDTH = local_mem_cfg_pkg::LOCAL_MEM_DATA_WIDTH,
-    parameter BURST_CNT_WIDTH = local_mem_cfg_pkg::LOCAL_MEM_BURST_CNT_WIDTH,
+    parameter ADDR_WIDTH = 0,
+    parameter DATA_WIDTH = 0,
+    parameter BURST_CNT_WIDTH = 0,
 
     // This parameter does not affect the interface. Instead, it is a guide to
     // the master indicating the waitrequestAllowance behavior offered by
@@ -52,7 +56,7 @@ interface ofs_plat_local_mem_avalon_if
     // A hack to work around compilers complaining of circular dependence
     // incorrectly when trying to make a new ofs_plat_local_mem_if from an
     // existing one's parameters.
-    localparam NUM_BANKS_ = $bits(logic [NUM_BANKS:0]) - 1;
+    localparam NUM_INSTANCES_ = $bits(logic [NUM_INSTANCES:0]) - 1;
     localparam ADDR_WIDTH_ = $bits(logic [ADDR_WIDTH:0]) - 1;
     localparam DATA_WIDTH_ = $bits(logic [DATA_WIDTH:0]) - 1;
     localparam BURST_CNT_WIDTH_ = $bits(logic [BURST_CNT_WIDTH:0]) - 1;
@@ -60,30 +64,30 @@ interface ofs_plat_local_mem_avalon_if
     // Number of bytes in a data line
     localparam DATA_N_BYTES = (DATA_WIDTH + 7) / 8;
 
-    logic 			clk;
-    logic			reset;
+    logic clk;
+    logic reset;
 
     // Signals
-    logic                       waitrequest;
-    logic [DATA_WIDTH-1:0]      readdata;
-    logic                       readdatavalid;
+    logic waitrequest;
+    logic [DATA_WIDTH-1:0] readdata;
+    logic readdatavalid;
 
-    logic [ADDR_WIDTH-1:0]      address;
-    logic                       write;
-    logic                       read;
+    logic [ADDR_WIDTH-1:0] address;
+    logic write;
+    logic read;
     logic [BURST_CNT_WIDTH-1:0] burstcount;
     logic [DATA_WIDTH-1:0]      writedata;
     logic [DATA_N_BYTES-1:0]    byteenable;
 
     // Debugging state.  This will typically be driven to a constant by the
     // code that instantiates the interface object.
-    logic [$clog2(NUM_BANKS)-1:0] bank_number;
+    logic [$clog2(NUM_INSTANCES)-1:0] instance_number;
 
 
     //
-    // Connection from a module toward the platform (FPGA Interface Manager)
+    // Connection from master toward slave
     //
-    modport to_fiu
+    modport to_slave
        (
         input  clk,
         input  reset,
@@ -99,14 +103,14 @@ interface ofs_plat_local_mem_avalon_if
         output writedata,
         output byteenable,
 
-        output bank_number
+        output instance_number
         );
 
 
     //
-    // Connection from a module toward the AFU
+    // Connection from slave toward master
     //
-    modport to_afu
+    modport to_master
        (
         output clk,
         output reset,
@@ -122,13 +126,12 @@ interface ofs_plat_local_mem_avalon_if
         input  writedata,
         input  byteenable,
 
-        output bank_number
+        output instance_number
         );
 
 
-
     //
-    //   Debugging
+    // Debugging
     //
 
     // synthesis translate_off
@@ -144,9 +147,10 @@ interface ofs_plat_local_mem_avalon_if
                 // Read request
                 if (! reset && read && ! waitrequest)
                 begin
-                    $fwrite(log_fd, "%m: %t bank %0d read 0x%x burst 0x%x\n",
+                    $fwrite(log_fd, "%m: %t %s %0d read 0x%x burst 0x%x\n",
                             $time,
-                            bank_number,
+                            ofs_plat_log_pkg::instance_name[LOG_CLASS],
+                            instance_number,
                             address,
                             burstcount);
                 end
@@ -154,18 +158,20 @@ interface ofs_plat_local_mem_avalon_if
                 // Read response
                 if (! reset && readdatavalid)
                 begin
-                    $fwrite(log_fd, "%m: %t bank %0d resp 0x%x\n",
+                    $fwrite(log_fd, "%m: %t %s %0d resp 0x%x\n",
                             $time,
-                            bank_number,
+                            ofs_plat_log_pkg::instance_name[LOG_CLASS],
+                            instance_number,
                             readdata);
                 end
 
                 // Write request
                 if (! reset && write && ! waitrequest)
                 begin
-                    $fwrite(log_fd, "%m: %t bank %0d write 0x%x burst 0x%x mask 0x%x data 0x%x\n",
+                    $fwrite(log_fd, "%m: %t %s %0d write 0x%x burst 0x%x mask 0x%x data 0x%x\n",
                             $time,
-                            bank_number,
+                            ofs_plat_log_pkg::instance_name[LOG_CLASS],
+                            instance_number,
                             address,
                             burstcount,
                             byteenable,
@@ -176,5 +182,4 @@ interface ofs_plat_local_mem_avalon_if
     end
     // synthesis translate_on
 
-endinterface // ofs_plat_local_mem_avalon_if
-
+endinterface // ofs_plat_avalon_mem_if

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2019, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,32 +29,32 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 //
-// Wire together two local memory Avalon instances.
+// Wire together two Avalon memory instances.
 //
-module ofs_plat_local_mem_avalon_if_connect
+module ofs_plat_avalon_mem_if_connect
    (
-    ofs_plat_local_mem_avalon_if.to_fiu mem_fiu,
-    ofs_plat_local_mem_avalon_if.to_afu mem_afu
+    ofs_plat_avalon_mem_if.to_slave mem_slave,
+    ofs_plat_avalon_mem_if.to_master mem_master
     );
 
     always_comb
     begin
-        mem_afu.clk = mem_fiu.clk;
-        mem_afu.reset = mem_fiu.reset;
+        mem_master.clk = mem_slave.clk;
+        mem_master.reset = mem_slave.reset;
 
-        mem_afu.waitrequest = mem_fiu.waitrequest;
-        mem_afu.readdata = mem_fiu.readdata;
-        mem_afu.readdatavalid = mem_fiu.readdatavalid;
+        mem_master.waitrequest = mem_slave.waitrequest;
+        mem_master.readdata = mem_slave.readdata;
+        mem_master.readdatavalid = mem_slave.readdatavalid;
 
-        mem_fiu.burstcount = mem_afu.burstcount;
-        mem_fiu.writedata = mem_afu.writedata;
-        mem_fiu.address = mem_afu.address;
-        mem_fiu.write = mem_afu.write;
-        mem_fiu.read = mem_afu.read;
-        mem_fiu.byteenable = mem_afu.byteenable;
+        mem_slave.burstcount = mem_master.burstcount;
+        mem_slave.writedata = mem_master.writedata;
+        mem_slave.address = mem_master.address;
+        mem_slave.write = mem_master.write;
+        mem_slave.read = mem_master.read;
+        mem_slave.byteenable = mem_master.byteenable;
 
         // Debugging signal
-        mem_afu.bank_number = mem_fiu.bank_number;
+        mem_master.instance_number = mem_slave.instance_number;
     end
 
-endmodule // ofs_plat_local_mem_avalon_if_connect
+endmodule // ofs_plat_avalon_mem_if_connect

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2019, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,43 +31,43 @@
 //
 // A simple version of Avalon MM interface register stage insertion.
 // Waitrequest is treated as an almost full protocol, with the assumption
-// that the FIU end of the connection can handle at least as many
+// that the slave end of the connection can handle at least as many
 // requests as the depth of the pipeline plus the latency of
-// forwarding waitrequest from the FIU side to the AFU side.
+// forwarding waitrequest from the slave side to the master side.
 //
 
-module ofs_plat_local_mem_avalon_if_reg_simple
+module ofs_plat_avalon_mem_if_reg_simple
   #(
     // Number of stages to add when registering inputs or outputs
     parameter N_REG_STAGES = 1,
     parameter N_WAITREQUEST_STAGES = N_REG_STAGES
     )
    (
-    ofs_plat_local_mem_avalon_if.to_fiu mem_fiu,
-    ofs_plat_local_mem_avalon_if.to_afu mem_afu
+    ofs_plat_avalon_mem_if.to_slave mem_slave,
+    ofs_plat_avalon_mem_if.to_master mem_master
     );
 
     genvar s;
     generate
         if (N_REG_STAGES == 0)
         begin : wires
-            ofs_plat_local_mem_avalon_if_connect conn(.mem_fiu, .mem_afu);
+            ofs_plat_avalon_mem_if_connect conn(.mem_slave, .mem_master);
         end
         else
         begin : regs
             // Pipeline stages.
-            ofs_plat_local_mem_avalon_if
+            ofs_plat_avalon_mem_if
               #(
-                .NUM_BANKS(mem_fiu.NUM_BANKS_),
-                .ADDR_WIDTH(mem_fiu.ADDR_WIDTH_),
-                .DATA_WIDTH(mem_fiu.DATA_WIDTH_),
-                .BURST_CNT_WIDTH(mem_fiu.BURST_CNT_WIDTH_)
+                .NUM_INSTANCES(mem_slave.NUM_INSTANCES_),
+                .ADDR_WIDTH(mem_slave.ADDR_WIDTH_),
+                .DATA_WIDTH(mem_slave.DATA_WIDTH_),
+                .BURST_CNT_WIDTH(mem_slave.BURST_CNT_WIDTH_)
                 )
                 mem_pipe[N_REG_STAGES+1]();
 
-            // Map mem_fiu to stage 0 (wired) to make the for loop below simpler.
-            ofs_plat_local_mem_avalon_if_connect conn0(.mem_fiu(mem_fiu),
-                                                       .mem_afu(mem_pipe[0]));
+            // Map mem_slave to stage 0 (wired) to make the for loop below simpler.
+            ofs_plat_avalon_mem_if_connect conn0(.mem_slave(mem_slave),
+                                                 .mem_master(mem_pipe[0]));
 
             // Inject the requested number of stages
             for (s = 1; s <= N_REG_STAGES; s = s + 1)
@@ -75,7 +75,7 @@ module ofs_plat_local_mem_avalon_if_reg_simple
                 assign mem_pipe[s].clk = mem_pipe[s-1].clk;
                 assign mem_pipe[s].reset = mem_pipe[s-1].reset;
 
-                always_ff @(posedge mem_fiu.clk)
+                always_ff @(posedge mem_slave.clk)
                 begin
                     // Waitrequest is a different pipeline, implemented below.
                     mem_pipe[s].waitrequest <= 1'b1;
@@ -90,7 +90,7 @@ module ofs_plat_local_mem_avalon_if_reg_simple
                     mem_pipe[s-1].read <= mem_pipe[s].read;
                     mem_pipe[s-1].byteenable <= mem_pipe[s].byteenable;
 
-                    if (mem_fiu.reset)
+                    if (mem_slave.reset)
                     begin
                         mem_pipe[s-1].write <= 1'b0;
                         mem_pipe[s-1].read <= 1'b0;
@@ -98,45 +98,45 @@ module ofs_plat_local_mem_avalon_if_reg_simple
                 end
 
                 // Debugging signal
-                assign mem_pipe[s].bank_number = mem_pipe[s-1].bank_number;
+                assign mem_pipe[s].instance_number = mem_pipe[s-1].instance_number;
             end
 
 
-            // waitrequest is a shift register, with mem_fiu.waitrequest entering
+            // waitrequest is a shift register, with mem_slave.waitrequest entering
             // at bit 0.
             logic [N_WAITREQUEST_STAGES:0] mem_waitrequest_pipe;
-            assign mem_waitrequest_pipe[0] = mem_fiu.waitrequest;
+            assign mem_waitrequest_pipe[0] = mem_slave.waitrequest;
 
-            always_ff @(posedge mem_fiu.clk)
+            always_ff @(posedge mem_slave.clk)
             begin
                 // Shift the waitrequest pipeline
                 mem_waitrequest_pipe[N_WAITREQUEST_STAGES:1] <=
-                    mem_fiu.reset ? {N_WAITREQUEST_STAGES{1'b1}} :
-                                    mem_waitrequest_pipe[N_WAITREQUEST_STAGES-1:0];
+                    mem_slave.reset ? {N_WAITREQUEST_STAGES{1'b1}} :
+                                      mem_waitrequest_pipe[N_WAITREQUEST_STAGES-1:0];
             end
 
 
-            // Map mem_afu to the last stage (wired)
+            // Map mem_master to the last stage (wired)
             always_comb
             begin
-                mem_afu.clk = mem_pipe[N_REG_STAGES].clk;
-                mem_afu.reset = mem_pipe[N_REG_STAGES].reset;
+                mem_master.clk = mem_pipe[N_REG_STAGES].clk;
+                mem_master.reset = mem_pipe[N_REG_STAGES].reset;
 
-                mem_afu.waitrequest = mem_waitrequest_pipe[N_WAITREQUEST_STAGES];
-                mem_afu.readdata = mem_pipe[N_REG_STAGES].readdata;
-                mem_afu.readdatavalid = mem_pipe[N_REG_STAGES].readdatavalid;
+                mem_master.waitrequest = mem_waitrequest_pipe[N_WAITREQUEST_STAGES];
+                mem_master.readdata = mem_pipe[N_REG_STAGES].readdata;
+                mem_master.readdatavalid = mem_pipe[N_REG_STAGES].readdatavalid;
 
-                mem_pipe[N_REG_STAGES].burstcount = mem_afu.burstcount;
-                mem_pipe[N_REG_STAGES].writedata = mem_afu.writedata;
-                mem_pipe[N_REG_STAGES].address = mem_afu.address;
-                mem_pipe[N_REG_STAGES].write = mem_afu.write && ! mem_afu.waitrequest;
-                mem_pipe[N_REG_STAGES].read = mem_afu.read && ! mem_afu.waitrequest;
-                mem_pipe[N_REG_STAGES].byteenable = mem_afu.byteenable;
+                mem_pipe[N_REG_STAGES].burstcount = mem_master.burstcount;
+                mem_pipe[N_REG_STAGES].writedata = mem_master.writedata;
+                mem_pipe[N_REG_STAGES].address = mem_master.address;
+                mem_pipe[N_REG_STAGES].write = mem_master.write && ! mem_master.waitrequest;
+                mem_pipe[N_REG_STAGES].read = mem_master.read && ! mem_master.waitrequest;
+                mem_pipe[N_REG_STAGES].byteenable = mem_master.byteenable;
 
                 // Debugging signal
-                mem_afu.bank_number = mem_pipe[N_REG_STAGES].bank_number;
+                mem_master.instance_number = mem_pipe[N_REG_STAGES].instance_number;
             end
         end
     endgenerate
 
-endmodule // ofs_plat_local_mem_avalon_if_reg_simple
+endmodule // ofs_plat_avalon_mem_if_reg_simple

--- a/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if.sv
@@ -51,10 +51,10 @@ interface ofs_plat_local_GROUP_mem_if
     // existing one's parameters.
     localparam NUM_BANKS_ = $bits(logic [NUM_BANKS:0]) - 1;
 
-    ofs_plat_local_mem_avalon_if
+    ofs_plat_avalon_mem_if
       #(
         .LOG_CLASS(ENABLE_LOG ? ofs_plat_log_pkg::LOCAL_MEM : ofs_plat_log_pkg::NONE),
-        .NUM_BANKS(NUM_BANKS),
+        .NUM_INSTANCES(NUM_BANKS),
         .ADDR_WIDTH(`OFS_PLAT_PARAM_LOCAL_MEM_GROUP_ADDR_WIDTH),
         .DATA_WIDTH(`OFS_PLAT_PARAM_LOCAL_MEM_GROUP_DATA_WIDTH),
         .BURST_CNT_WIDTH(`OFS_PLAT_PARAM_LOCAL_MEM_GROUP_BURST_CNT_WIDTH),

--- a/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if_tie_off.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if_tie_off.sv
@@ -37,7 +37,7 @@
 
 module ofs_plat_local_mem_GROUP_if_tie_off
    (
-    ofs_plat_local_mem_avalon_if.to_fiu bank
+    ofs_plat_avalon_mem_if.to_slave bank
     );
 
     always_comb

--- a/plat_if_develop/ofs_plat_if/src/rtl/utils/ofs_plat_log_pkg.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/utils/ofs_plat_log_pkg.sv
@@ -43,11 +43,19 @@ package ofs_plat_log_pkg;
     }
     t_log_class;
 
+    // What is the name for an instance of the class?
+    localparam string instance_name[3] = {
+        "",
+        "port",
+        "bank"
+        };
+
     int log_fds[3] = '{3{-1}};
-    localparam string log_names[3] = { "",
-                                "log_ofs_plat_host_chan.tsv",
-                                "log_ofs_plat_local_mem.tsv"
-                                };
+    localparam string log_names[3] = {
+        "",
+        "log_ofs_plat_host_chan.tsv",
+        "log_ofs_plat_local_mem.tsv"
+        };
 
     // Get the file descriptor for a group
     function automatic int get_fd(t_log_class g);

--- a/plat_if_develop/ofs_plat_if/src/sources_generic.txt
+++ b/plat_if_develop/ofs_plat_if/src/sources_generic.txt
@@ -1,6 +1,7 @@
 # Generic (platform-independent) sources. These are copied to the target
 # ofs_plat_if tree as it is configured.
 par
+rtl/base_ifcs
 rtl/compat
 rtl/ofs_plat_if.vh
 rtl/platform_if.vh


### PR DESCRIPTION
Instead of an Avalon interface specific to local memory, define a generic
Avalon memory master/slave interface class and support modules. These can
then be used on any Avalon bus.