### PR TITLE
Generalize the Avalon interface beyond just local memory

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.sv
@@ -71,6 +71,8 @@ interface ofs_plat_avalon_mem_if
     logic waitrequest;
     logic [DATA_WIDTH-1:0] readdata;
     logic readdatavalid;
+    logic writeresponsevalid;
+    logic [1:0] response;
 
     logic [ADDR_WIDTH-1:0] address;
     logic write;
@@ -83,7 +85,6 @@ interface ofs_plat_avalon_mem_if
     // code that instantiates the interface object.
     logic [$clog2(NUM_INSTANCES)-1:0] instance_number;
 
-
     //
     // Connection from master toward slave
     //
@@ -95,6 +96,8 @@ interface ofs_plat_avalon_mem_if
         input  waitrequest,
         input  readdata,
         input  readdatavalid,
+        input  writeresponsevalid,
+        input  response,
 
         output address,
         output write,
@@ -118,6 +121,8 @@ interface ofs_plat_avalon_mem_if
         output waitrequest,
         output readdata,
         output readdatavalid,
+        output writeresponsevalid,
+        output response,
 
         input  address,
         input  write,
@@ -158,11 +163,12 @@ interface ofs_plat_avalon_mem_if
                 // Read response
                 if (! reset && readdatavalid)
                 begin
-                    $fwrite(log_fd, "%m: %t %s %0d resp 0x%x\n",
+                    $fwrite(log_fd, "%m: %t %s %0d read resp 0x%x (%d)\n",
                             $time,
                             ofs_plat_log_pkg::instance_name[LOG_CLASS],
                             instance_number,
-                            readdata);
+                            readdata,
+                            response);
                 end
 
                 // Write request
@@ -176,6 +182,16 @@ interface ofs_plat_avalon_mem_if
                             burstcount,
                             byteenable,
                             writedata);
+                end
+
+                // Write response
+                if (! reset && writeresponsevalid)
+                begin
+                    $fwrite(log_fd, "%m: %t %s %0d write resp (%d)\n",
+                            $time,
+                            ofs_plat_log_pkg::instance_name[LOG_CLASS],
+                            instance_number,
+                            response);
                 end
             end
         end

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.vh
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if.vh
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2019, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+`ifndef __OFS_PLAT_AVALON_MEM_IF_VH__
+`define __OFS_PLAT_AVALON_MEM_IF_VH__
+
+//
+// Utilities for operating on interface ofs_plat_avalon_mem_if.
+//
+// Ideally, the macros here would instead be tasks in the interface intself.
+// Unfortunately, tasks within an interface can't use the interface as a
+// parameter type. You can't build a task in an interface that operates on an
+// instance of interface object. Instead, we resort to these ugly macros.
+// Macros allow modules to operate without knowing some of the minor interface
+// fields.
+//
+
+`define ofs_plat_avalon_mem_if_from_master_to_slave_comb(MEM_SLAVE, MEM_MASTER) \
+    MEM_SLAVE.burstcount = MEM_MASTER.burstcount; \
+    MEM_SLAVE.writedata = MEM_MASTER.writedata; \
+    MEM_SLAVE.address = MEM_MASTER.address; \
+    MEM_SLAVE.write = MEM_MASTER.write; \
+    MEM_SLAVE.read = MEM_MASTER.read; \
+    MEM_SLAVE.byteenable = MEM_MASTER.byteenable
+
+`define ofs_plat_avalon_mem_if_from_master_to_slave_ff(MEM_SLAVE, MEM_MASTER) \
+    MEM_SLAVE.burstcount <= MEM_MASTER.burstcount; \
+    MEM_SLAVE.writedata <= MEM_MASTER.writedata; \
+    MEM_SLAVE.address <= MEM_MASTER.address; \
+    MEM_SLAVE.write <= MEM_MASTER.write; \
+    MEM_SLAVE.read <= MEM_MASTER.read; \
+    MEM_SLAVE.byteenable <= MEM_MASTER.byteenable
+
+
+// Note these do not set clk, reset or instance_number since those
+// fields may be handled specially.
+`define ofs_plat_avalon_mem_if_from_slave_to_master_comb(MEM_MASTER, MEM_SLAVE) \
+    MEM_MASTER.waitrequest = MEM_SLAVE.waitrequest; \
+    MEM_MASTER.readdata = MEM_SLAVE.readdata; \
+    MEM_MASTER.readdatavalid = MEM_SLAVE.readdatavalid; \
+    MEM_MASTER.writeresponsevalid = MEM_SLAVE.writeresponsevalid; \
+    MEM_MASTER.response = MEM_SLAVE.response
+
+// Note the lack of waitrequest in the non-blocking assignment. The
+// ready/enable protocol must be handled explicitly.
+`define ofs_plat_avalon_mem_if_from_slave_to_master_ff(MEM_MASTER, MEM_SLAVE) \
+    MEM_MASTER.readdata <= MEM_SLAVE.readdata; \
+    MEM_MASTER.readdatavalid <= MEM_SLAVE.readdatavalid; \
+    MEM_MASTER.writeresponsevalid <= MEM_SLAVE.writeresponsevalid; \
+    MEM_MASTER.response <= MEM_SLAVE.response
+
+
+//
+// Initialization macros ought to just be tasks in the interface, but QuestSim
+// treats tasks as active even if they are never invoked, leading to errors
+// about multiple drivers.
+//
+
+`define ofs_plat_avalon_mem_if_init_master_comb(MEM_MASTER) \
+    MEM_MASTER.burstcount = '0; \
+    MEM_MASTER.writedata = '0; \
+    MEM_MASTER.address = '0; \
+    MEM_MASTER.write = 1'b0; \
+    MEM_MASTER.read = 1'b0; \
+    MEM_MASTER.byteenable = '0
+
+`define ofs_plat_avalon_mem_if_init_master_ff(MEM_MASTER) \
+    MEM_MASTER.burstcount <= '0; \
+    MEM_MASTER.writedata <= '0; \
+    MEM_MASTER.address <= '0; \
+    MEM_MASTER.write <= 1'b0; \
+    MEM_MASTER.read <= 1'b0; \
+    MEM_MASTER.byteenable <= '0
+
+`define ofs_plat_avalon_mem_if_init_slave_comb(MEM_SLAVE) \
+    MEM_SLAVE.waitrequest = 1'b0; \
+    MEM_SLAVE.readdata = '0; \
+    MEM_SLAVE.readdatavalid = 1'b0; \
+    MEM_SLAVE.writeresponsevalid = 1'b0; \
+    MEM_SLAVE.response = 2'b0
+
+`define ofs_plat_avalon_mem_if_init_slave_ff(MEM_SLAVE) \
+    MEM_SLAVE.waitrequest <= 1'b0; \
+    MEM_SLAVE.readdata <= '0; \
+    MEM_SLAVE.readdatavalid <= 1'b0; \
+    MEM_SLAVE.writeresponsevalid <= 1'b0; \
+    MEM_SLAVE.response <= 2'b0
+
+
+`endif // __OFS_PLAT_AVALON_MEM_IF_VH__

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_async_shim.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_async_shim.sv
@@ -97,6 +97,18 @@ module ofs_plat_avalon_mem_if_async_shim
         .m0_debugaccess()
         );
 
+    // These signals currently do not pass through the bridge
+    assign mem_master.response = 'x;
+    always_ff @(posedge mem_master.clk)
+    begin
+        // Fake a writeresponsevalid
+        mem_master.writeresponsevalid <= mem_master.write && ! mem_master.waitrequest;
+        if (mem_master.reset)
+        begin
+            mem_master.writeresponsevalid <= 1'b0;
+        end
+    end
+
     // Compute mem_master.waitrequest
     generate
         if (COMMAND_ALMFULL_THRESHOLD == 0)

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
@@ -28,6 +28,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+`include "ofs_plat_if.vh"
+
 //
 // Wire together two Avalon memory instances.
 //
@@ -42,16 +44,8 @@ module ofs_plat_avalon_mem_if_connect
         mem_master.clk = mem_slave.clk;
         mem_master.reset = mem_slave.reset;
 
-        mem_master.waitrequest = mem_slave.waitrequest;
-        mem_master.readdata = mem_slave.readdata;
-        mem_master.readdatavalid = mem_slave.readdatavalid;
-
-        mem_slave.burstcount = mem_master.burstcount;
-        mem_slave.writedata = mem_master.writedata;
-        mem_slave.address = mem_master.address;
-        mem_slave.write = mem_master.write;
-        mem_slave.read = mem_master.read;
-        mem_slave.byteenable = mem_master.byteenable;
+        `ofs_plat_avalon_mem_if_from_master_to_slave_comb(mem_slave, mem_master);
+        `ofs_plat_avalon_mem_if_from_slave_to_master_comb(mem_master, mem_slave);
 
         // Debugging signal
         mem_master.instance_number = mem_slave.instance_number;

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_connect.sv
@@ -39,11 +39,11 @@ module ofs_plat_avalon_mem_if_connect
     ofs_plat_avalon_mem_if.to_master mem_master
     );
 
+    assign mem_master.clk = mem_slave.clk;
+    assign mem_master.reset = mem_slave.reset;
+
     always_comb
     begin
-        mem_master.clk = mem_slave.clk;
-        mem_master.reset = mem_slave.reset;
-
         `ofs_plat_avalon_mem_if_from_master_to_slave_comb(mem_slave, mem_master);
         `ofs_plat_avalon_mem_if_from_slave_to_master_comb(mem_master, mem_slave);
 

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_gen_write_response.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_gen_write_response.sv
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2019, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+`include "ofs_plat_if.vh"
+
+//
+// Generate a writeresponsevalid signal by tracking write requests.
+// This module may be used when a writeresponsevalid signal is desired but
+// the underlying device doesn't offer one.
+//
+module ofs_plat_avalon_mem_if_gen_write_response
+  #(
+    parameter BURST_CNT_WIDTH = 0
+    )
+   (
+    input  logic clk,
+    input  logic reset,
+
+    input  logic write,
+    input  logic waitrequest,
+    input  logic [BURST_CNT_WIDTH-1 : 0] burstcount,
+
+    output logic writeresponsevalid
+    );
+
+    typedef logic [BURST_CNT_WIDTH-1 : 0] t_burst_cnt;
+
+    logic did_write, did_write_q;
+    t_burst_cnt burst_cnt, bursts_rem;
+    logic is_eop;
+
+    always_ff @(posedge clk)
+    begin
+        // Did write data arrive?
+        did_write <= write && ! waitrequest;
+        did_write_q <= did_write;
+
+        burst_cnt <= burstcount;
+        if (did_write)
+        begin
+            // In the middle of a burst?
+            if (bursts_rem != t_burst_cnt'(0))
+            begin
+                // Yes -- decrement the count
+                is_eop <= (bursts_rem == t_burst_cnt'(1));
+                bursts_rem <= bursts_rem - t_burst_cnt'(1);
+            end
+            else
+            begin
+                // Start of a new burst
+                is_eop <= (burst_cnt == t_burst_cnt'(1));
+                bursts_rem <= burst_cnt - t_burst_cnt'(1);
+            end
+        end
+
+        // One write response is expected per burst, at the end of the burst.
+        writeresponsevalid <= did_write_q && is_eop;
+        if (reset)
+        begin
+            writeresponsevalid <= 1'b0;
+            bursts_rem <= t_burst_cnt'(0);
+        end
+    end
+
+endmodule // ofs_plat_avalon_mem_if_gen_write_response

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg.sv
@@ -88,7 +88,7 @@ module ofs_plat_avalon_mem_if_reg
                     .s0_waitrequest(mem_pipe[s].waitrequest),
                     .s0_readdata(mem_pipe[s].readdata),
                     .s0_readdatavalid(mem_pipe[s].readdatavalid),
-                    .s0_response(),
+                    .s0_response(mem_pipe[s].response),
                     .s0_burstcount(mem_pipe[s].burstcount),
                     .s0_writedata(mem_pipe[s].writedata),
                     .s0_address(mem_pipe[s].address), 
@@ -100,7 +100,7 @@ module ofs_plat_avalon_mem_if_reg
                     .m0_waitrequest(mem_pipe[s - 1].waitrequest),
                     .m0_readdata(mem_pipe[s - 1].readdata),
                     .m0_readdatavalid(mem_pipe[s - 1].readdatavalid),
-                    .m0_response('x),
+                    .m0_response(mem_pipe[s - 1].response),
                     .m0_burstcount(mem_pipe[s - 1].burstcount),
                     .m0_writedata(mem_pipe[s - 1].writedata),
                     .m0_address(mem_pipe[s - 1].address), 
@@ -109,6 +109,16 @@ module ofs_plat_avalon_mem_if_reg
                     .m0_byteenable(mem_pipe[s - 1].byteenable),
                     .m0_debugaccess()
                     );
+
+                // The bridge doesn't handle writeresponsevalid
+                always_ff @(posedge mem_pipe[s].clk)
+                begin
+                    mem_pipe[s].writeresponsevalid <= mem_pipe[s-1].writeresponsevalid;
+                    if (mem_pipe[s].reset)
+                    begin
+                        mem_pipe[s].writeresponsevalid <= 1'b0;
+                    end
+                end
 
                 // Debugging signal
                 assign mem_pipe[s].instance_number = mem_pipe[s-1].instance_number;

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
@@ -28,6 +28,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+`include "ofs_plat_if.vh"
+
 //
 // A simple version of Avalon MM interface register stage insertion.
 // Waitrequest is treated as an almost full protocol, with the assumption
@@ -80,15 +82,8 @@ module ofs_plat_avalon_mem_if_reg_simple
                     // Waitrequest is a different pipeline, implemented below.
                     mem_pipe[s].waitrequest <= 1'b1;
 
-                    mem_pipe[s].readdata <= mem_pipe[s-1].readdata;
-                    mem_pipe[s].readdatavalid <= mem_pipe[s-1].readdatavalid;
-
-                    mem_pipe[s-1].burstcount <= mem_pipe[s].burstcount;
-                    mem_pipe[s-1].writedata <= mem_pipe[s].writedata;
-                    mem_pipe[s-1].address <= mem_pipe[s].address;
-                    mem_pipe[s-1].write <= mem_pipe[s].write;
-                    mem_pipe[s-1].read <= mem_pipe[s].read;
-                    mem_pipe[s-1].byteenable <= mem_pipe[s].byteenable;
+                    `ofs_plat_avalon_mem_if_from_slave_to_master_ff(mem_pipe[s], mem_pipe[s-1]);
+                    `ofs_plat_avalon_mem_if_from_master_to_slave_ff(mem_pipe[s-1], mem_pipe[s]);
 
                     if (mem_slave.reset)
                     begin
@@ -122,16 +117,12 @@ module ofs_plat_avalon_mem_if_reg_simple
                 mem_master.clk = mem_pipe[N_REG_STAGES].clk;
                 mem_master.reset = mem_pipe[N_REG_STAGES].reset;
 
+                `ofs_plat_avalon_mem_if_from_slave_to_master_comb(mem_master, mem_pipe[N_REG_STAGES]);
                 mem_master.waitrequest = mem_waitrequest_pipe[N_WAITREQUEST_STAGES];
-                mem_master.readdata = mem_pipe[N_REG_STAGES].readdata;
-                mem_master.readdatavalid = mem_pipe[N_REG_STAGES].readdatavalid;
 
-                mem_pipe[N_REG_STAGES].burstcount = mem_master.burstcount;
-                mem_pipe[N_REG_STAGES].writedata = mem_master.writedata;
-                mem_pipe[N_REG_STAGES].address = mem_master.address;
+                `ofs_plat_avalon_mem_if_from_master_to_slave_comb(mem_pipe[N_REG_STAGES], mem_master);
                 mem_pipe[N_REG_STAGES].write = mem_master.write && ! mem_master.waitrequest;
                 mem_pipe[N_REG_STAGES].read = mem_master.read && ! mem_master.waitrequest;
-                mem_pipe[N_REG_STAGES].byteenable = mem_master.byteenable;
 
                 // Debugging signal
                 mem_master.instance_number = mem_pipe[N_REG_STAGES].instance_number;

--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/ofs_plat_avalon_mem_if_reg_simple.sv
@@ -112,11 +112,11 @@ module ofs_plat_avalon_mem_if_reg_simple
 
 
             // Map mem_master to the last stage (wired)
+            assign mem_master.clk = mem_pipe[N_REG_STAGES].clk;
+            assign mem_master.reset = mem_pipe[N_REG_STAGES].reset;
+
             always_comb
             begin
-                mem_master.clk = mem_pipe[N_REG_STAGES].clk;
-                mem_master.reset = mem_pipe[N_REG_STAGES].reset;
-
                 `ofs_plat_avalon_mem_if_from_slave_to_master_comb(mem_master, mem_pipe[N_REG_STAGES]);
                 mem_master.waitrequest = mem_waitrequest_pipe[N_WAITREQUEST_STAGES];
 

--- a/plat_if_develop/ofs_plat_if/src/rtl/host_chan/native_ccip/ccip/ofs_plat_host_ccip_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/host_chan/native_ccip/ccip/ofs_plat_host_ccip_if.sv
@@ -39,7 +39,7 @@ interface ofs_plat_host_ccip_if
     parameter ENABLE_LOG = 0         // Log events for this instance?
     );
 
-    logic clk;
+    wire clk;
     logic reset;    // ACTIVE HIGH
 
     // CCI-P Protocol Error Detected

--- a/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if_tie_off.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/local_mem/native_avalon/ofs_plat_local_mem_GROUP_if_tie_off.sv
@@ -42,12 +42,7 @@ module ofs_plat_local_mem_GROUP_if_tie_off
 
     always_comb
     begin
-        bank.burstcount = 0;
-        bank.writedata = 0;
-        bank.address = 0;
-        bank.write = 0;
-        bank.read = 0;
-        bank.byteenable = 0;
+        `ofs_plat_avalon_mem_if_init_master_comb(bank);
     end
 
 endmodule // ofs_plat_local_mem_GROUP_if_tie_off

--- a/plat_if_develop/ofs_plat_if/src/rtl/ofs_plat_if.template.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ofs_plat_if.template.sv
@@ -51,7 +51,7 @@ interface ofs_plat_if
     );
 
     // Required: Platform top-level clocks
-    t_ofs_plat_clocks clocks;
+    wire t_ofs_plat_clocks clocks;
 
     // Required: ACTIVE HIGH Soft Reset (clocked by pClk)
     logic softReset;

--- a/plat_if_develop/ofs_plat_if/src/rtl/ofs_plat_if.vh
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ofs_plat_if.vh
@@ -38,6 +38,7 @@
 
 `include "ofs_plat_if_top_config.vh"
 `include "ofs_plat_host_ccip_if.vh"
+`include "ofs_plat_avalon_mem_if.vh"
 
 // Compatibility mode for OPAE SDK's Platform Interface Manager
 `ifndef AFU_TOP_REQUIRES_OFS_PLAT_IF_AFU

--- a/plat_if_develop/ofs_plat_if/src/sim/ase_top_ofs_plat.sv
+++ b/plat_if_develop/ofs_plat_if/src/sim/ase_top_ofs_plat.sv
@@ -54,14 +54,11 @@ module ase_top_ofs_plat
     // Clocks
     //
 
-    always_comb
-    begin
-        plat_ifc.clocks.pClk = pClk;
-        plat_ifc.clocks.pClkDiv2 = pClkDiv2;
-        plat_ifc.clocks.pClkDiv4 = pClkDiv4;
-        plat_ifc.clocks.uClk_usr = uClk_usr;
-        plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
-    end
+    assign plat_ifc.clocks.pClk = pClk;
+    assign plat_ifc.clocks.pClkDiv2 = pClkDiv2;
+    assign plat_ifc.clocks.pClkDiv4 = pClkDiv4;
+    assign plat_ifc.clocks.uClk_usr = uClk_usr;
+    assign plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
 
 
     //
@@ -115,22 +112,25 @@ module ase_top_ofs_plat
             assign plat_ifc.local_mem.banks[b].clk = mem_banks_clk[b];
             assign plat_ifc.local_mem.banks[b].reset = plat_ifc.softReset;
 
-            // The model doesn't generate either "response" or "writeresponsevalid".
-            // Generate them here.
             assign plat_ifc.local_mem.banks[b].response = 2'b0;
-            logic did_write;
 
-            always_ff @(plat_ifc.local_mem.banks[b].clk)
-            begin
-                did_write <= plat_ifc.local_mem.banks[b].write &&
-                             ! plat_ifc.local_mem.banks[b].waitrequest;
+            // The model doesn't generate "writeresponsevalid".
+            // Generate it here.
+            ofs_plat_avalon_mem_if_gen_write_response
+              #(
+                .BURST_CNT_WIDTH(local_mem_cfg_pkg::LOCAL_MEM_BURST_CNT_WIDTH)
+                )
+              wr_resp
+               (
+                .clk(plat_ifc.local_mem.banks[b].clk),
+                .reset(plat_ifc.local_mem.banks[b].reset),
 
-                plat_ifc.local_mem.banks[b].writeresponsevalid <= did_write;
-                if (plat_ifc.local_mem.banks[b].reset)
-                begin
-                    plat_ifc.local_mem.banks[b].writeresponsevalid <= 1'b0;
-                end
-            end
+                .write(plat_ifc.local_mem.banks[b].write),
+                .waitrequest(plat_ifc.local_mem.banks[b].waitrequest),
+                .burstcount(plat_ifc.local_mem.banks[b].burstcount),
+
+                .writeresponsevalid(plat_ifc.local_mem.banks[b].writeresponsevalid)
+                );
         end
     endgenerate
 `endif

--- a/plat_if_develop/ofs_plat_if/src/sim/ase_top_ofs_plat.sv
+++ b/plat_if_develop/ofs_plat_if/src/sim/ase_top_ofs_plat.sv
@@ -114,6 +114,23 @@ module ase_top_ofs_plat
         begin : b_reset
             assign plat_ifc.local_mem.banks[b].clk = mem_banks_clk[b];
             assign plat_ifc.local_mem.banks[b].reset = plat_ifc.softReset;
+
+            // The model doesn't generate either "response" or "writeresponsevalid".
+            // Generate them here.
+            assign plat_ifc.local_mem.banks[b].response = 2'b0;
+            logic did_write;
+
+            always_ff @(plat_ifc.local_mem.banks[b].clk)
+            begin
+                did_write <= plat_ifc.local_mem.banks[b].write &&
+                             ! plat_ifc.local_mem.banks[b].waitrequest;
+
+                plat_ifc.local_mem.banks[b].writeresponsevalid <= did_write;
+                if (plat_ifc.local_mem.banks[b].reset)
+                begin
+                    plat_ifc.local_mem.banks[b].writeresponsevalid <= 1'b0;
+                end
+            end
         end
     endgenerate
 `endif

--- a/plat_if_update/ofs_plat_if_compat/SR-5.0.3-Release/files/green_top.sv
+++ b/plat_if_update/ofs_plat_if_compat/SR-5.0.3-Release/files/green_top.sv
@@ -54,26 +54,23 @@ module green_top(
   // wraps all ports to the AFU.
   ofs_plat_if plat_ifc();
 
-  always_comb
-  begin
-    // Clocks
-    plat_ifc.clocks.pClk = pClk;
-    plat_ifc.clocks.pClkDiv2 = pClkDiv2;
-    plat_ifc.clocks.pClkDiv4 = pClkDiv4;
-    plat_ifc.clocks.uClk_usr = uClk_usr;
-    plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
+  // Clocks
+  assign plat_ifc.clocks.pClk = pClk;
+  assign plat_ifc.clocks.pClkDiv2 = pClkDiv2;
+  assign plat_ifc.clocks.pClkDiv4 = pClkDiv4;
+  assign plat_ifc.clocks.uClk_usr = uClk_usr;
+  assign plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
 
-    // Reset, etc.
-    plat_ifc.softReset = pck_cp2af_softReset;
-    plat_ifc.pwrState = pck_cp2af_pwrState;
+  // Reset, etc.
+  assign plat_ifc.softReset = pck_cp2af_softReset;
+  assign plat_ifc.pwrState = pck_cp2af_pwrState;
 
-    // Host CCI-P port
-    plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
-    plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
-    plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
-    plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
-    bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
-  end
+  // Host CCI-P port
+  assign plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
+  assign plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
+  assign plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
+  assign plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
+  assign bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
 
 
   // ===========================================

--- a/plat_if_update/ofs_plat_if_compat/SR-6.4.0/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/SR-6.4.0/files/green_bs.sv
@@ -130,16 +130,18 @@ module green_bs
   `ifdef AFU_TOP_REQUIRES_OFS_PLAT_IF_AFU
     // OFS platform interface passes all HSSI ports through the top-level
     // wrapper.
+    assign plat_ifc.hssi.ports[0].f2a_tx_clk = hssi.f2a_tx_clk;
+    assign plat_ifc.hssi.ports[0].f2a_tx_clk2 = hssi.f2a_tx_clk2;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clk_ln0 = hssi.f2a_rx_clk_ln0;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clk2_ln0 = hssi.f2a_rx_clk2_ln0;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clk_ln4 = hssi.f2a_rx_clk_ln4;
+    assign plat_ifc.hssi.ports[0].f2a_prmgmt_ctrl_clk = hssi.f2a_prmgmt_ctrl_clk;
+
     always_comb
     begin
-        plat_ifc.hssi.ports[0].f2a_tx_clk = hssi.f2a_tx_clk;
-        plat_ifc.hssi.ports[0].f2a_tx_clk2 = hssi.f2a_tx_clk2;
         plat_ifc.hssi.ports[0].f2a_tx_locked = hssi.f2a_tx_locked;
        
-        plat_ifc.hssi.ports[0].f2a_rx_clk_ln0 = hssi.f2a_rx_clk_ln0;
-        plat_ifc.hssi.ports[0].f2a_rx_clk2_ln0 = hssi.f2a_rx_clk2_ln0;
         plat_ifc.hssi.ports[0].f2a_rx_locked_ln0 = hssi.f2a_rx_locked_ln0;
-        plat_ifc.hssi.ports[0].f2a_rx_clk_ln4 = hssi.f2a_rx_clk_ln4;
         plat_ifc.hssi.ports[0].f2a_rx_locked_ln4 = hssi.f2a_rx_locked_ln4;
     
         hssi.a2f_init_start = plat_ifc.hssi.ports[0].a2f_init_start;
@@ -181,7 +183,6 @@ module green_bs
 
         hssi.a2f_prmgmt_fatal_err = plat_ifc.hssi.ports[0].a2f_prmgmt_fatal_err;
         hssi.a2f_prmgmt_dout = plat_ifc.hssi.ports[0].a2f_prmgmt_dout;
-        plat_ifc.hssi.ports[0].f2a_prmgmt_ctrl_clk = hssi.f2a_prmgmt_ctrl_clk;
         plat_ifc.hssi.ports[0].f2a_prmgmt_cmd = hssi.f2a_prmgmt_cmd;
         plat_ifc.hssi.ports[0].f2a_prmgmt_addr = hssi.f2a_prmgmt_addr;
         plat_ifc.hssi.ports[0].f2a_prmgmt_din = hssi.f2a_prmgmt_din;

--- a/plat_if_update/ofs_plat_if_compat/SR-6.4.0/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/SR-6.4.0/files/green_bs.sv
@@ -74,26 +74,23 @@ module green_bs
     // wraps all ports to the AFU.
     ofs_plat_if plat_ifc();
 
-    always_comb
-    begin
-        // Clocks
-        plat_ifc.clocks.pClk = Clk_400;
-        plat_ifc.clocks.pClkDiv2 = Clk_200;
-        plat_ifc.clocks.pClkDiv4 = Clk_100;
-        plat_ifc.clocks.uClk_usr = uClk_usr;
-        plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
+    // Clocks
+    assign plat_ifc.clocks.pClk = Clk_400;
+    assign plat_ifc.clocks.pClkDiv2 = Clk_200;
+    assign plat_ifc.clocks.pClkDiv4 = Clk_100;
+    assign plat_ifc.clocks.uClk_usr = uClk_usr;
+    assign plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
 
-        // Reset, etc.
-        plat_ifc.softReset = SoftReset;
-        plat_ifc.pwrState = pck_cp2af_pwrState;
+    // Reset, etc.
+    assign plat_ifc.softReset = SoftReset;
+    assign plat_ifc.pwrState = pck_cp2af_pwrState;
 
-        // Host CCI-P port
-        plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
-        plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
-        plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
-        plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
-        bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
-    end
+    // Host CCI-P port
+    assign plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
+    assign plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
+    assign plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
+    assign plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
+    assign bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
 
 
 // ===========================================

--- a/plat_if_update/ofs_plat_if_compat/a10_gx_pac_ias/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/a10_gx_pac_ias/files/green_bs.sv
@@ -103,26 +103,23 @@ module green_bs
     // wraps all ports to the AFU.
     ofs_plat_if plat_ifc();
 
-    always_comb
-    begin
-        // Clocks
-        plat_ifc.clocks.pClk = Clk_400;
-        plat_ifc.clocks.pClkDiv2 = Clk_200;
-        plat_ifc.clocks.pClkDiv4 = Clk_100;
-        plat_ifc.clocks.uClk_usr = uClk_usr;
-        plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
+    // Clocks
+    assign plat_ifc.clocks.pClk = Clk_400;
+    assign plat_ifc.clocks.pClkDiv2 = Clk_200;
+    assign plat_ifc.clocks.pClkDiv4 = Clk_100;
+    assign plat_ifc.clocks.uClk_usr = uClk_usr;
+    assign plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
 
-        // Reset, etc.
-        plat_ifc.softReset = SoftReset;
-        plat_ifc.pwrState = pck_cp2af_pwrState;
+    // Reset, etc.
+    assign plat_ifc.softReset = SoftReset;
+    assign plat_ifc.pwrState = pck_cp2af_pwrState;
 
-        // Host CCI-P port
-        plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
-        plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
-        plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
-        plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
-        bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
-    end
+    // Host CCI-P port
+    assign plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
+    assign plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
+    assign plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
+    assign plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
+    assign bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
 
 // ===========================================
 // AFU - Remote Debug JTAG IP instantiation

--- a/plat_if_update/ofs_plat_if_compat/a10_gx_pac_ias/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/a10_gx_pac_ias/files/green_bs.sv
@@ -190,13 +190,10 @@ module green_bs
              .q(DDR4b_softReset)
     );
 
-    always_comb
-    begin
-        plat_ifc.local_mem.banks[0].clk = DDR4a_USERCLK;
-        plat_ifc.local_mem.banks[0].reset = DDR4a_softReset;
-        plat_ifc.local_mem.banks[1].clk = DDR4b_USERCLK;
-        plat_ifc.local_mem.banks[1].reset = DDR4b_softReset;
-    end
+    assign plat_ifc.local_mem.banks[0].clk = DDR4a_USERCLK;
+    assign plat_ifc.local_mem.banks[0].reset = DDR4a_softReset;
+    assign plat_ifc.local_mem.banks[1].clk = DDR4b_USERCLK;
+    assign plat_ifc.local_mem.banks[1].reset = DDR4b_softReset;
 
     ddr_avmm_bridge #(
             .DATA_WIDTH        (512),
@@ -263,16 +260,18 @@ module green_bs
 `ifdef INCLUDE_ETHERNET
     // OFS platform interface passes all HSSI ports through the top-level
     // wrapper.
+    assign plat_ifc.hssi.ports[0].f2a_tx_clk = hssi.f2a_tx_clk;
+    assign plat_ifc.hssi.ports[0].f2a_tx_clkx2 = hssi.f2a_tx_clkx2;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clk_ln0 = hssi.f2a_rx_clk_ln0;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clkx2_ln0 = hssi.f2a_rx_clkx2_ln0;
+    assign plat_ifc.hssi.ports[0].f2a_rx_clk_ln4 = hssi.f2a_rx_clk_ln4;
+    assign plat_ifc.hssi.ports[0].f2a_prmgmt_ctrl_clk = hssi.f2a_prmgmt_ctrl_clk;
+
     always_comb
     begin
-        plat_ifc.hssi.ports[0].f2a_tx_clk = hssi.f2a_tx_clk;
-        plat_ifc.hssi.ports[0].f2a_tx_clkx2 = hssi.f2a_tx_clkx2;
         plat_ifc.hssi.ports[0].f2a_tx_locked = hssi.f2a_tx_locked;
        
-        plat_ifc.hssi.ports[0].f2a_rx_clk_ln0 = hssi.f2a_rx_clk_ln0;
-        plat_ifc.hssi.ports[0].f2a_rx_clkx2_ln0 = hssi.f2a_rx_clkx2_ln0;
         plat_ifc.hssi.ports[0].f2a_rx_locked_ln0 = hssi.f2a_rx_locked_ln0;
-        plat_ifc.hssi.ports[0].f2a_rx_clk_ln4 = hssi.f2a_rx_clk_ln4;
         plat_ifc.hssi.ports[0].f2a_rx_locked_ln4 = hssi.f2a_rx_locked_ln4;
     
         hssi.a2f_tx_analogreset = plat_ifc.hssi.ports[0].a2f_tx_analogreset;
@@ -314,7 +313,6 @@ module green_bs
 
         hssi.a2f_prmgmt_fatal_err = plat_ifc.hssi.ports[0].a2f_prmgmt_fatal_err;
         hssi.a2f_prmgmt_dout = plat_ifc.hssi.ports[0].a2f_prmgmt_dout;
-        plat_ifc.hssi.ports[0].f2a_prmgmt_ctrl_clk = hssi.f2a_prmgmt_ctrl_clk;
         plat_ifc.hssi.ports[0].f2a_prmgmt_cmd = hssi.f2a_prmgmt_cmd;
         plat_ifc.hssi.ports[0].f2a_prmgmt_addr = hssi.f2a_prmgmt_addr;
         plat_ifc.hssi.ports[0].f2a_prmgmt_din = hssi.f2a_prmgmt_din;

--- a/plat_if_update/ofs_plat_if_compat/d5005_ias/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/d5005_ias/files/green_bs.sv
@@ -141,26 +141,23 @@ module green_bs
    // wraps all ports to the AFU.
    ofs_plat_if plat_ifc();
 
-   always_comb
-   begin
-      // Clocks
-      plat_ifc.clocks.pClk = Clk_400;
-      plat_ifc.clocks.pClkDiv2 = Clk_200;
-      plat_ifc.clocks.pClkDiv4 = Clk_100;
-      plat_ifc.clocks.uClk_usr = uClk_usr;
-      plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
+   // Clocks
+   assign plat_ifc.clocks.pClk = Clk_400;
+   assign plat_ifc.clocks.pClkDiv2 = Clk_200;
+   assign plat_ifc.clocks.pClkDiv4 = Clk_100;
+   assign plat_ifc.clocks.uClk_usr = uClk_usr;
+   assign plat_ifc.clocks.uClk_usrDiv2 = uClk_usrDiv2;
 
-      // Reset, etc.
-      plat_ifc.softReset = SoftReset;
-      plat_ifc.pwrState = pck_cp2af_pwrState;
+   // Reset, etc.
+   assign plat_ifc.softReset = SoftReset;
+   assign plat_ifc.pwrState = pck_cp2af_pwrState;
 
-      // Host CCI-P port
-      plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
-      plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
-      plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
-      plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
-      bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
-   end
+   // Host CCI-P port
+   assign plat_ifc.host_chan.ports[0].clk = plat_ifc.clocks.pClk;
+   assign plat_ifc.host_chan.ports[0].reset = plat_ifc.softReset;
+   assign plat_ifc.host_chan.ports[0].error = pck_cp2af_error;
+   assign plat_ifc.host_chan.ports[0].sRx = bus_ccip_Rx;
+   assign bus_ccip_Tx = plat_ifc.host_chan.ports[0].sTx;
 
 
 // ===========================================

--- a/plat_if_update/ofs_plat_if_compat/d5005_ias/files/green_bs.sv
+++ b/plat_if_update/ofs_plat_if_compat/d5005_ias/files/green_bs.sv
@@ -209,9 +209,13 @@ module green_bs
     // mappings from DDR4x PR wires.
     pr_avalon_mem_if pr_local_mem[NUM_FIU_LOCAL_MEM_BANKS]();
 
+    assign pr_local_mem[0].clk = DDR4a_USERCLK;
+    assign pr_local_mem[1].clk = DDR4b_USERCLK;
+    assign pr_local_mem[2].clk = DDR4c_USERCLK;
+    assign pr_local_mem[3].clk = DDR4d_USERCLK;
+
     always_comb
     begin
-        pr_local_mem[0].clk = DDR4a_USERCLK;
         pr_local_mem[0].waitrequest = DDR4a_waitrequest;
         pr_local_mem[0].readdata = DDR4a_readdata;
         pr_local_mem[0].readdatavalid = DDR4a_readdatavalid;
@@ -223,7 +227,6 @@ module green_bs
         DDR4a_byteenable = pr_local_mem[0].byteenable;
         pr_local_mem[0].ecc_interrupt = DDR4a_ecc_interrupt;
 
-        pr_local_mem[1].clk = DDR4b_USERCLK;
         pr_local_mem[1].waitrequest = DDR4b_waitrequest;
         pr_local_mem[1].readdata = DDR4b_readdata;
         pr_local_mem[1].readdatavalid = DDR4b_readdatavalid;
@@ -235,7 +238,6 @@ module green_bs
         DDR4b_byteenable = pr_local_mem[1].byteenable;
         pr_local_mem[1].ecc_interrupt = DDR4b_ecc_interrupt;
 
-        pr_local_mem[2].clk = DDR4c_USERCLK;
         pr_local_mem[2].waitrequest = DDR4c_waitrequest;
         pr_local_mem[2].readdata = DDR4c_readdata;
         pr_local_mem[2].readdatavalid = DDR4c_readdatavalid;
@@ -247,7 +249,6 @@ module green_bs
         DDR4c_byteenable = pr_local_mem[2].byteenable;
         pr_local_mem[2].ecc_interrupt = DDR4c_ecc_interrupt;
 
-        pr_local_mem[3].clk = DDR4d_USERCLK;
         pr_local_mem[3].waitrequest = DDR4d_waitrequest;
         pr_local_mem[3].readdata = DDR4d_readdata;
         pr_local_mem[3].readdatavalid = DDR4d_readdatavalid;
@@ -346,13 +347,18 @@ module green_bs
         generate
             for (qsfp_num = 0; qsfp_num < NUM_QSFP_IF; qsfp_num = qsfp_num + 1)
             begin : hssi_map
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_tx_clkout = hssi[qsfp_num].f2a_tx_clkout;
+                // assign plat_ifc.hssi.ports[qsfp_num].f2a_tx_clkout2 = hssi[qsfp_num].f2a_tx_clkout2;
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_tx_parallel_clk_x1[0] = hssi[qsfp_num].f2a_tx_parallel_clk_x1[0];
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_tx_parallel_clk_x2[0] = hssi[qsfp_num].f2a_tx_parallel_clk_x2[0];
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_rx_clkout = hssi[qsfp_num].f2a_rx_clkout;
+                // assign plat_ifc.hssi.ports[qsfp_num].f2a_rx_clkout2 = hssi[qsfp_num].f2a_rx_clkout2;
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_rx_parallel_clk_x1[0] = hssi[qsfp_num].f2a_rx_parallel_clk_x1[0];
+                assign plat_ifc.hssi.ports[qsfp_num].f2a_rx_parallel_clk_x2[0] = hssi[qsfp_num].f2a_rx_parallel_clk_x2[0];
+
                 always_comb
                 begin
                     // TX PCS
-                    plat_ifc.hssi.ports[qsfp_num].f2a_tx_clkout = hssi[qsfp_num].f2a_tx_clkout;
-                    // plat_ifc.hssi.ports[qsfp_num].f2a_tx_clkout2 = hssi[qsfp_num].f2a_tx_clkout2;
-                    plat_ifc.hssi.ports[qsfp_num].f2a_tx_parallel_clk_x1[0] = hssi[qsfp_num].f2a_tx_parallel_clk_x1[0];
-                    plat_ifc.hssi.ports[qsfp_num].f2a_tx_parallel_clk_x2[0] = hssi[qsfp_num].f2a_tx_parallel_clk_x2[0];
                     plat_ifc.hssi.ports[qsfp_num].f2a_tx_ready = hssi[qsfp_num].f2a_tx_ready;
                     plat_ifc.hssi.ports[qsfp_num].f2a_tx_fifo_empty = hssi[qsfp_num].f2a_tx_fifo_empty;
                     plat_ifc.hssi.ports[qsfp_num].f2a_tx_fifo_full = hssi[qsfp_num].f2a_tx_fifo_full;
@@ -361,10 +367,6 @@ module green_bs
                     hssi[qsfp_num].a2f_tx_parallel_data = plat_ifc.hssi.ports[qsfp_num].a2f_tx_parallel_data;
 
                     // RX PCS
-                    plat_ifc.hssi.ports[qsfp_num].f2a_rx_clkout = hssi[qsfp_num].f2a_rx_clkout;
-                    // plat_ifc.hssi.ports[qsfp_num].f2a_rx_clkout2 = hssi[qsfp_num].f2a_rx_clkout2;
-                    plat_ifc.hssi.ports[qsfp_num].f2a_rx_parallel_clk_x1[0] = hssi[qsfp_num].f2a_rx_parallel_clk_x1[0];
-                    plat_ifc.hssi.ports[qsfp_num].f2a_rx_parallel_clk_x2[0] = hssi[qsfp_num].f2a_rx_parallel_clk_x2[0];
                     plat_ifc.hssi.ports[qsfp_num].f2a_rx_ready = hssi[qsfp_num].f2a_rx_ready;
                     hssi[qsfp_num].a2f_rx_bitslip = plat_ifc.hssi.ports[qsfp_num].a2f_rx_bitslip;
                     plat_ifc.hssi.ports[qsfp_num].f2a_rx_fifo_empty = hssi[qsfp_num].f2a_rx_fifo_empty;


### PR DESCRIPTION
- Add macros for connecting instances of the interface. Tasks would have been better,
  since they are part of the language, but tasks within interfaces aren't stable enough
  across the toolchains.

- Add waitresponsevalid and response to the core OFS Avalon interface definition.

- Declare clocks in interfaces as wires.
