### PR TITLE
Add support for the PCIe SS mode with MMIO on AXI-Lite

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/config/defaults.ini
+++ b/plat_if_develop/ofs_plat_if/src/config/defaults.ini
@@ -54,6 +54,9 @@ data_width=512
 ;; AFU's MMIO address size (byte-level, despite PCIe using 32 bit
 ;; DWORD granularity.
 mmio_addr_width=18
+;; Default MMIO expected bus width. Generally, 64 is required for
+;; device feature lists.
+mmio_data_width=64
 
 ;; Boolean (0/1) indicating whether the platform supports byte-enable
 ;; to update only a portion of a cache line.

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/afu_ifcs/include/ofs_plat_host_chan_GROUP_pkg.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/afu_ifcs/include/ofs_plat_host_chan_GROUP_pkg.sv
@@ -50,5 +50,14 @@ package ofs_plat_host_chan_@group@_pkg;
     // AFU's MMIO address size (byte-level, despite PCIe using 32 bit
     // DWORD granularity.
     localparam MMIO_ADDR_WIDTH_BYTES = `OFS_PLAT_PARAM_HOST_CHAN_@GROUP@_MMIO_ADDR_WIDTH;
+    localparam MMIO_DATA_WIDTH = `OFS_PLAT_PARAM_HOST_CHAN_@GROUP@_MMIO_DATA_WIDTH;
+
+    // Work out whether the MMIO interface supports 512 bit writes
+`ifdef OFS_PCIE_SS_PLAT_AXI_L_MMIO
+    // The PCIe SS AXI-Lite CSR does not support 512 bit MMIO writes
+    localparam MMIO_512_WRITE_SUPPORTED = 0;
+`else
+    localparam MMIO_512_WRITE_SUPPORTED = 1;
+`endif
 
 endpackage

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/includes/ofs_plat_host_chan_GROUP_as_axi_mem.vh
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/includes/ofs_plat_host_chan_GROUP_as_axi_mem.vh
@@ -55,4 +55,7 @@
     .DATA_WIDTH(BUSWIDTH), \
     .RID_WIDTH($clog2(BUSWIDTH / 32) + $bits(ofs_plat_host_chan_@group@_pcie_tlp_pkg::t_mmio_rd_tag))
 
+`define HOST_CHAN_@GROUP@_AXI_MMIO_PARAMS_DEFAULT \
+    `HOST_CHAN_@GROUP@_AXI_MMIO_PARAMS(ofs_plat_host_chan_@group@_pkg::MMIO_DATA_WIDTH)
+
 `endif // __OFS_PLAT_HOST_CHAN_@GROUP@_AS_AXI_MEM_RDWR__

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/includes/ofs_plat_host_chan_GROUP_pcie_tlp_pkg.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/includes/ofs_plat_host_chan_GROUP_pcie_tlp_pkg.sv
@@ -94,6 +94,13 @@ package ofs_plat_host_chan_@group@_pcie_tlp_pkg;
         1;
 `endif
 
+    // PCIe SS maps MMIO CSR traffic to AXI-Lite?
+`ifdef OFS_PCIE_SS_PLAT_AXI_L_MMIO
+    localparam MMIO_ON_AXI_L_FROM_FIM = 1;
+`else
+    localparam MMIO_ON_AXI_L_FROM_FIM = 0;
+`endif
+
     // Tags, reduced from the TLP's maximum size to the FIM-enforced maximum
     typedef logic [$clog2(MAX_OUTSTANDING_DMA_RD_REQS)-1 : 0] t_dma_rd_tag;
     typedef logic [$clog2(MAX_OUTSTANDING_MMIO_RD_REQS)-1 : 0] t_mmio_rd_tag;

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/ofs_plat_host_chan_GROUP_axis_pcie_tlp_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/ofs_plat_host_chan_GROUP_axis_pcie_tlp_if.sv
@@ -54,6 +54,22 @@ interface ofs_plat_host_chan_@group@_axis_pcie_tlp_if
     pcie_ss_hdr_pkg::ReqHdr_vf_num_t vf_num;
     logic vf_active;
 
+    // AXI-Lite CSR interface. On some platforms, the PCIe SS is configured to
+    // map MMIO reads and writes to an AXI-Lite interface that is separate from
+    // the TLP stream. The afu_csr_if is defined on all platforms to simplify
+    // conditional compilation, but is tied off on platforms where MMIO remains
+    // on the TLP streams.
+    ofs_plat_axi_mem_lite_if
+      #(
+        .LOG_CLASS(LOG_CLASS),
+        `HOST_CHAN_@GROUP@_AXI_MMIO_PARAMS_DEFAULT
+        )
+      afu_csr_if();
+
+    // Only set the instance_number for afu_csr_if. The clock may be different
+    // and will be set when initialized.
+    assign afu_csr_if.instance_number = instance_number;
+
     // AFU -> FIM TLP TX stream
     ofs_plat_axi_stream_if
       #(

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/ofs_plat_host_chan_GROUP_axis_pcie_tlp_if.vh
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/ofs_plat_host_chan_GROUP_axis_pcie_tlp_if.vh
@@ -31,6 +31,8 @@
 `ifndef __OFS_PLAT_HOST_CHAN_@GROUP@_AXIS_PCIE_TLP_IF__
 `define __OFS_PLAT_HOST_CHAN_@GROUP@_AXIS_PCIE_TLP_IF__
 
+`include "ofs_pcie_ss_cfg.vh"
+
 // Macro indicates which gasket is active
 `define OFS_PLAT_PARAM_HOST_CHAN_@GROUP@_GASKET_PCIE_SS 1
 

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/sim/ase_emul_pcie_ss_split_mmio.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/sim/ase_emul_pcie_ss_split_mmio.sv
@@ -1,0 +1,412 @@
+//
+// Copyright (c) 2022, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Emulate the PCIe SS mode in which MMIO (CSR) traffic is delivered on
+// an AXI-Lite bus separate from the TLP stream. The logic here manages
+// a FIM-side TLP stream with embedded MMIO. It filters out MMIO requests
+// coming from the FIM and moves them to afu_csr_axi_lite_if. CSR read
+// responses are merged back in to the FIM TLP stream.
+//
+// There is also a clock crossing, with the CSR AXI-Lite bus using a
+// separate clock.
+//
+
+// Only compile when OFS_PCIE_SS_PLAT_AXI_L_MMIO is defined, since older
+// platforms may not have ofs_fim_axi_lite_if defined.
+`ifdef OFS_PCIE_SS_PLAT_AXI_L_MMIO
+
+`include "ofs_plat_if.vh"
+
+module ase_emul_pcie_ss_split_mmio
+  #(
+    // PCIe PF/VF details
+    parameter pcie_ss_hdr_pkg::ReqHdr_pf_num_t PF_NUM,
+    parameter pcie_ss_hdr_pkg::ReqHdr_vf_num_t VF_NUM,
+    parameter VF_ACTIVE
+   )
+   (
+    ofs_fim_axi_lite_if.source afu_csr_axi_lite_if,
+
+    pcie_ss_axis_if.sink afu_tlp_tx_if,
+    pcie_ss_axis_if.source fim_tlp_tx_if,
+    pcie_ss_axis_if.source afu_tlp_rx_if,
+    pcie_ss_axis_if.sink fim_tlp_rx_if
+    );
+
+    wire clk = afu_tlp_tx_if.clk;
+    wire rst_n = afu_tlp_tx_if.rst_n;
+    wire csr_clk = afu_csr_axi_lite_if.clk;
+    logic csr_rst_n = 1'b0;
+
+    // Apply soft reset to the CSR interface
+    logic csr_flr_rst_n;
+    ofs_plat_prim_clock_crossing_reset flr_to_csr
+       (
+        .clk_src(clk),
+        .clk_dst(csr_clk),
+        .reset_in(rst_n),
+        .reset_out(csr_flr_rst_n)
+        );
+
+    always @(posedge csr_clk)
+    begin
+        csr_rst_n <= afu_csr_axi_lite_if.rst_n && csr_flr_rst_n;
+    end
+
+
+    localparam CSR_ADDR_WIDTH = afu_csr_axi_lite_if.AWADDR_WIDTH;
+    localparam CSR_DATA_WIDTH = afu_csr_axi_lite_if.WDATA_WIDTH;
+
+    // Byte address from TLP request header
+    function automatic logic [CSR_ADDR_WIDTH-1 : 0] tlp_hdr_addr(pcie_ss_hdr_pkg::PCIe_PUReqHdr_t hdr);
+        if (pcie_ss_hdr_pkg::func_is_addr64(hdr.fmt_type))
+            return CSR_ADDR_WIDTH'({ '0, hdr.host_addr_h, hdr.host_addr_l, 2'b0 });
+        else
+            return CSR_ADDR_WIDTH'({ '0, hdr.host_addr_h });
+    endfunction // tlp_hdr_addr
+
+
+    //
+    // Track TLP SOP in each direction
+    //
+    logic is_tx_sop, is_rx_sop;
+
+    always_ff @(posedge clk)
+    begin
+        if (afu_tlp_tx_if.tvalid && afu_tlp_tx_if.tready)
+        begin
+            is_tx_sop <= afu_tlp_tx_if.tlast;
+        end
+
+        if (fim_tlp_rx_if.tvalid && fim_tlp_rx_if.tready)
+        begin
+            is_rx_sop <= fim_tlp_rx_if.tlast;
+        end
+
+        if (!rst_n)
+        begin
+            is_tx_sop <= 1'b1;
+            is_rx_sop <= 1'b1;
+        end
+    end
+
+
+    //
+    // CSR read request (PCIe -> AFU) buffer and clock crossing
+    //
+    pcie_ss_hdr_pkg::PCIe_PUReqHdr_t fim_tlp_rx_hdr;
+    assign fim_tlp_rx_hdr = pcie_ss_hdr_pkg::PCIe_PUReqHdr_t'(fim_tlp_rx_if.tdata);
+    wire fim_tlp_rx_is_csr_rd = pcie_ss_hdr_pkg::func_is_mrd_req(fim_tlp_rx_hdr.fmt_type) &&
+                                is_rx_sop;
+
+    always_ff @(negedge clk)
+    begin
+        if (rst_n && fim_tlp_rx_is_csr_rd && fim_tlp_rx_if.tvalid)
+        begin
+            assert(pcie_ss_hdr_pkg::func_hdr_is_pu_mode(fim_tlp_rx_if.tuser_vendor)) else
+                $fatal(2, "** ERROR ** %m: MMIO read requests expected to be PU encoded!");
+            assert(fim_tlp_rx_hdr.length <= 2) else
+                $fatal(2, "** ERROR ** %m: MMIO read request packet too long!");
+            assert(fim_tlp_rx_if.tlast) else
+                $fatal(2, "** ERROR ** %m: MMIO read request packet not tlast!");
+        end
+    end
+
+    logic csr_rd_req_notFull;
+    pcie_ss_hdr_pkg::PCIe_PUReqHdr_t csr_rd_req_hdr;
+    logic csr_rd_req_deq;
+    logic csr_rd_req_notEmpty;
+
+    // Read state machine. The PCIe SS has no tags on CSR AXI-Lite reads,
+    // so allows only one request to be outstanding on the bus. The logic here
+    // uses csr_rd_req to hold TLP metadata for the outstanding request and
+    // a state machine to track an active request.
+    logic csr_rd_busy;
+    always_ff @(posedge csr_clk)
+    begin
+        if (afu_csr_axi_lite_if.arvalid && afu_csr_axi_lite_if.arready)
+            csr_rd_busy <= 1'b1;
+
+        if (!csr_rst_n || csr_rd_req_deq)
+            csr_rd_busy <= 1'b0;
+    end
+
+    ofs_plat_prim_fifo_dc
+      #(
+        .N_DATA_BITS($bits(pcie_ss_hdr_pkg::PCIe_PUReqHdr_t)),
+        .N_ENTRIES(64)
+        )
+      csr_rd_req_fifo
+       (
+        .enq_clk(clk),
+        .enq_reset_n(csr_rst_n),
+        // Push the entire header into the buffer. Some of the state will be
+        // needed to generate the response.
+        .enq_data(fim_tlp_rx_hdr),
+        .enq_en(fim_tlp_rx_is_csr_rd && fim_tlp_rx_if.tvalid && fim_tlp_rx_if.tready),
+        .notFull(csr_rd_req_notFull),
+        .almostFull(),
+
+        .deq_clk(csr_clk),
+        .deq_reset_n(csr_rst_n),
+        .first(csr_rd_req_hdr),
+        .deq_en(csr_rd_req_deq),
+        .notEmpty(csr_rd_req_notEmpty)
+        );
+
+    assign csr_rd_req_deq = afu_csr_axi_lite_if.rvalid && afu_csr_axi_lite_if.rready;
+    assign afu_csr_axi_lite_if.arvalid = csr_rd_req_notEmpty && !csr_rd_busy;
+    always_comb
+    begin
+        afu_csr_axi_lite_if.arprot = '0;
+
+        afu_csr_axi_lite_if.araddr = tlp_hdr_addr(csr_rd_req_hdr);
+        // The PCIe SS generates read addresses that are always aligned to the
+        // bus.
+        afu_csr_axi_lite_if.araddr[$clog2(CSR_DATA_WIDTH/8)-1 : 0] = '0;
+    end
+
+
+    //
+    // CSR read response (AFU -> PCIe) buffer and clock crossing
+    //
+    logic [CSR_DATA_WIDTH-1 : 0] csr_rd_rsp_data_out;
+    logic csr_rd_rsp_notEmpty;
+    logic csr_rd_rsp_deq;
+
+    // Generated CSR read TLP response. Build the header from the request header.
+    pcie_ss_hdr_pkg::PCIe_PUCplHdr_t csr_rd_rsp_hdr, csr_rd_rsp_hdr_out;
+    always_comb
+    begin
+        csr_rd_rsp_hdr = '0;
+        csr_rd_rsp_hdr.fmt_type = pcie_ss_hdr_pkg::ReqHdr_FmtType_e'(pcie_ss_hdr_pkg::PCIE_FMTTYPE_CPLD);
+        csr_rd_rsp_hdr.length = csr_rd_req_hdr.length;
+        csr_rd_rsp_hdr.req_id = csr_rd_req_hdr.req_id;
+        csr_rd_rsp_hdr.tag_l = csr_rd_req_hdr.tag_l;
+        csr_rd_rsp_hdr.tag_m = csr_rd_req_hdr.tag_m;
+        csr_rd_rsp_hdr.tag_h = csr_rd_req_hdr.tag_h;
+        csr_rd_rsp_hdr.TC = csr_rd_req_hdr.TC;
+        csr_rd_rsp_hdr.byte_count = csr_rd_req_hdr.length << 2;
+        csr_rd_rsp_hdr.low_addr = 7'(tlp_hdr_addr(csr_rd_req_hdr));
+
+        csr_rd_rsp_hdr.comp_id = { VF_NUM, 1'(VF_ACTIVE), PF_NUM };
+        csr_rd_rsp_hdr.pf_num = PF_NUM;
+        csr_rd_rsp_hdr.vf_num = VF_NUM;
+        csr_rd_rsp_hdr.vf_active = VF_ACTIVE;
+    end
+
+    ofs_plat_prim_fifo_dc
+      #(
+        .N_DATA_BITS($bits(pcie_ss_hdr_pkg::PCIe_PUCplHdr_t) + CSR_DATA_WIDTH),
+        .N_ENTRIES(64)
+        )
+      csr_rd_rsp_fifo
+       (
+        .enq_clk(csr_clk),
+        .enq_reset_n(csr_rst_n),
+        .enq_data({ csr_rd_rsp_hdr, afu_csr_axi_lite_if.rdata }),
+        .enq_en(afu_csr_axi_lite_if.rvalid && afu_csr_axi_lite_if.rready),
+        .notFull(afu_csr_axi_lite_if.rready),
+        .almostFull(),
+
+        .deq_clk(clk),
+        .deq_reset_n(rst_n),
+        .first({ csr_rd_rsp_hdr_out, csr_rd_rsp_data_out }),
+        .deq_en(csr_rd_rsp_deq),
+        .notEmpty(csr_rd_rsp_notEmpty)
+        );
+
+
+    // Response data. Complexity comes from moving 32 bit data to the right place.
+    logic [CSR_DATA_WIDTH-1 : 0] csr_rd_rsp_data;
+    logic [(CSR_DATA_WIDTH/8)-1 : 0] csr_rd_rsp_strb;
+
+    always_comb
+    begin
+        // 32 or smaller access to upper half of a 64 bit space?
+        csr_rd_rsp_data = csr_rd_rsp_data_out;
+        if (csr_rd_rsp_hdr_out.low_addr[2])
+            csr_rd_rsp_data[31:0] = csr_rd_rsp_data_out[63:32];
+
+        if (csr_rd_rsp_hdr_out.length == 1)
+            csr_rd_rsp_strb = 'hf;
+        else
+            csr_rd_rsp_strb = ~'0;
+    end
+
+
+    //
+    // CSR write address request (PCIe -> AFU) buffer and clock crossing
+    //
+    wire fim_tlp_rx_is_csr_wr = pcie_ss_hdr_pkg::func_is_mwr_req(fim_tlp_rx_hdr.fmt_type) &&
+                                is_rx_sop;
+    wire [CSR_ADDR_WIDTH-1 : 0] fim_tlp_rx_addr = tlp_hdr_addr(fim_tlp_rx_hdr);
+
+    always_ff @(negedge clk)
+    begin
+        if (rst_n && fim_tlp_rx_is_csr_wr && fim_tlp_rx_if.tvalid)
+        begin
+            assert(pcie_ss_hdr_pkg::func_hdr_is_pu_mode(fim_tlp_rx_if.tuser_vendor)) else
+                $fatal(2, "** ERROR ** %m: MMIO write requests expected to be PU encoded!");
+            assert(fim_tlp_rx_hdr.length <= 2) else
+                $fatal(2, "** ERROR ** %m: MMIO write request packet too long! AXI-Lite CSR supports up to 64 bit writes.");
+            assert(fim_tlp_rx_if.tlast) else
+                $fatal(2, "** ERROR ** %m: MMIO write request packet not tlast!");
+        end
+    end
+
+    logic csr_wr_req_notFull;
+    logic [CSR_ADDR_WIDTH-1 : 0] csr_wr_req_addr;
+
+    ofs_plat_prim_fifo_dc
+      #(
+        .N_DATA_BITS(CSR_ADDR_WIDTH),
+        .N_ENTRIES(64)
+        )
+      csr_wr_req_fifo
+       (
+        .enq_clk(clk),
+        .enq_reset_n(csr_rst_n),
+        .enq_data(fim_tlp_rx_addr),
+        .enq_en(fim_tlp_rx_is_csr_wr && fim_tlp_rx_if.tvalid && fim_tlp_rx_if.tready),
+        .notFull(csr_wr_req_notFull),
+        .almostFull(),
+
+        .deq_clk(csr_clk),
+        .deq_reset_n(csr_rst_n),
+        .first(csr_wr_req_addr),
+        .deq_en(afu_csr_axi_lite_if.awvalid && afu_csr_axi_lite_if.awready),
+        .notEmpty(afu_csr_axi_lite_if.awvalid)
+        );
+
+    assign afu_csr_axi_lite_if.awaddr = csr_wr_req_addr;
+    assign afu_csr_axi_lite_if.awprot = '0;
+
+    // No PCIe response is expected for CSR writes. Consume and drop B.
+    assign afu_csr_axi_lite_if.bready = 1'b1;
+
+
+    //
+    // CSR write data (PCIe -> AFU) buffer and clock crossing
+    //
+    logic csr_wr_data_notFull;
+    logic [CSR_DATA_WIDTH-1 : 0] csr_wr_data;
+    logic [(CSR_DATA_WIDTH/8)-1 : 0] csr_wr_strb;
+
+    always_comb
+    begin
+        if (fim_tlp_rx_hdr.length > 1)
+        begin
+            // Write larger than 32 bits. Assume it is the full bus.
+            csr_wr_data = fim_tlp_rx_if.tdata[$bits(pcie_ss_hdr_pkg::PCIe_PUReqHdr_t) +: CSR_DATA_WIDTH];
+            csr_wr_strb = ~0;
+        end
+        else
+        begin
+            // 32 bits or smaller. Use the low dword address bit to pick either
+            // the first or second dword in the write data buffer.
+            csr_wr_data = '0;
+            csr_wr_data[(32 * fim_tlp_rx_addr[2]) +: 32] =
+                fim_tlp_rx_if.tdata[$bits(pcie_ss_hdr_pkg::PCIe_PUReqHdr_t) +: 32];
+
+            // Apply the incoming byte mask to the appropriate dword.
+            csr_wr_strb = 0;
+            csr_wr_strb[(4 * fim_tlp_rx_addr[2]) +: 4] = fim_tlp_rx_hdr.first_dw_be;
+        end
+    end
+
+    ofs_plat_prim_fifo_dc
+      #(
+        .N_DATA_BITS((CSR_DATA_WIDTH/8) + CSR_DATA_WIDTH),
+        .N_ENTRIES(64)
+        )
+      csr_wr_data_fifo
+       (
+        .enq_clk(clk),
+        .enq_reset_n(csr_rst_n),
+        .enq_data({ csr_wr_strb, csr_wr_data }),
+        .enq_en(fim_tlp_rx_is_csr_wr && fim_tlp_rx_if.tvalid && fim_tlp_rx_if.tready),
+        .notFull(csr_wr_data_notFull),
+        .almostFull(),
+
+        .deq_clk(csr_clk),
+        .deq_reset_n(csr_rst_n),
+        .first({ afu_csr_axi_lite_if.wstrb, afu_csr_axi_lite_if.wdata }),
+        .deq_en(afu_csr_axi_lite_if.wvalid && afu_csr_axi_lite_if.wready),
+        .notEmpty(afu_csr_axi_lite_if.wvalid)
+        );
+
+
+    //
+    // Control logic
+    //
+
+    // Ready for TLP from FIM?
+    wire csr_req_ready = !is_rx_sop ||
+                         (csr_rd_req_notFull && csr_wr_req_notFull && csr_wr_data_notFull);
+    assign fim_tlp_rx_if.tready = afu_tlp_rx_if.tready && csr_req_ready;
+    assign afu_tlp_rx_if.tvalid = fim_tlp_rx_if.tvalid && csr_req_ready &&
+                                  !fim_tlp_rx_is_csr_rd && !fim_tlp_rx_is_csr_wr;
+
+    // Ready for CSR read response as a TLP to the FIM? If not, forward normal TLP
+    // TX traffic.
+    wire pick_csr_rd_rsp = is_tx_sop && csr_rd_rsp_notEmpty;
+    assign csr_rd_rsp_deq = pick_csr_rd_rsp && fim_tlp_tx_if.tready;
+    assign fim_tlp_tx_if.tvalid = pick_csr_rd_rsp || afu_tlp_tx_if.tvalid;
+    assign afu_tlp_tx_if.tready = fim_tlp_tx_if.tready && !pick_csr_rd_rsp;
+
+    // Connect data. Only tready/tvalid will determine packet routing.
+    always_comb
+    begin
+        afu_tlp_rx_if.tlast = fim_tlp_rx_if.tlast;
+        afu_tlp_rx_if.tuser_vendor = fim_tlp_rx_if.tuser_vendor;
+        afu_tlp_rx_if.tdata = fim_tlp_rx_if.tdata;
+        afu_tlp_rx_if.tkeep = fim_tlp_rx_if.tkeep;
+
+        if (pick_csr_rd_rsp)
+        begin
+            fim_tlp_tx_if.tlast = 1'b1;
+            fim_tlp_tx_if.tuser_vendor = '0;
+            fim_tlp_tx_if.tdata = { '0, csr_rd_rsp_data, csr_rd_rsp_hdr_out };
+            fim_tlp_tx_if.tkeep = { '0, csr_rd_rsp_strb, 16'hffff };
+        end
+        else
+        begin
+            fim_tlp_tx_if.tlast = afu_tlp_tx_if.tlast;
+            fim_tlp_tx_if.tuser_vendor = afu_tlp_tx_if.tuser_vendor;
+            fim_tlp_tx_if.tdata = afu_tlp_tx_if.tdata;
+            fim_tlp_tx_if.tkeep = afu_tlp_tx_if.tkeep;
+        end
+    end
+
+endmodule // ase_emul_pcie_ss_split_mmio
+
+`endif //  `ifdef OFS_PCIE_SS_PLAT_AXI_L_MMIO

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/ofs_plat_host_chan_GROUP_gen_mmio_axi_lite.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/ofs_plat_host_chan_GROUP_gen_mmio_axi_lite.sv
@@ -1,0 +1,229 @@
+//
+// Copyright (c) 2022, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+//
+// Connect the PIM's MMIO traffic to an AXI-Lite interface provided by the FIM.
+//
+
+`include "ofs_plat_if.vh"
+
+module ofs_plat_host_chan_@group@_gen_mmio_axi_lite
+   (
+    input  logic clk,
+    input  logic reset_n,
+
+    // AXI-Lite interface from host
+    ofs_plat_axi_mem_lite_if.to_source fiu_mmio_if,
+
+    // MMIO requests from host to AFU (t_gen_tx_mmio_afu_req)
+    ofs_plat_axi_stream_if.to_sink host_mmio_req,
+
+    // AFU responses (t_gen_tx_mmio_afu_rsp)
+    ofs_plat_axi_stream_if.to_source host_mmio_rsp,
+
+    output logic error
+    );
+
+    import ofs_plat_host_chan_@group@_gen_tlps_pkg::*;
+
+    wire csr_clk = fiu_mmio_if.clk;
+    wire csr_reset_n = fiu_mmio_if.reset_n;
+
+    //
+    // Add a skid buffer, both for timing and because the skid buffer uses
+    // FIFOs internally that have ready signals that are independent of
+    // incoming valids. This simplifies arbitration.
+    //
+    ofs_plat_axi_mem_lite_if
+      #(
+        `OFS_PLAT_AXI_MEM_LITE_IF_REPLICATE_PARAMS(fiu_mmio_if)
+        )
+      axi_mmio_if();
+
+    assign axi_mmio_if.clk = csr_clk;
+    assign axi_mmio_if.reset_n = csr_reset_n;
+    assign axi_mmio_if.instance_number = fiu_mmio_if.instance_number;
+
+    ofs_plat_axi_mem_lite_if_skid skid
+       (
+        .mem_source(fiu_mmio_if),
+        .mem_sink(axi_mmio_if)
+        );
+
+
+    // MMIO requests to the AFU in the csr_clk domain
+    ofs_plat_axi_stream_if
+      #(
+        .TDATA_TYPE(t_gen_tx_mmio_afu_req),
+        .TUSER_TYPE(logic)
+        )
+      host_to_afu_req();
+
+    assign host_to_afu_req.clk = csr_clk;
+    assign host_to_afu_req.reset_n = csr_reset_n;
+    assign host_to_afu_req.instance_number = fiu_mmio_if.instance_number;
+
+
+    //
+    // Arbitration. The host request stream accepts only a read or a write
+    // in a cycle, not both.
+    //
+
+    wire pending_rd_req = axi_mmio_if.arvalid;
+    // Writes send the commit on B immediately. There is no response to the host
+    // anyway, so delaying the B response has no semantic value.
+    wire pending_wr_req = axi_mmio_if.awvalid && axi_mmio_if.wvalid && axi_mmio_if.bready;
+    logic arb_grant_wr, arb_grand_rd;
+
+    ofs_plat_prim_arb_rr
+      #(
+        .NUM_CLIENTS(2)
+        )
+      arb
+       (
+        .clk(csr_clk),
+        .reset_n(csr_reset_n),
+        .ena(host_to_afu_req.tready),
+        .request({ pending_wr_req, pending_rd_req }),
+        .grant({ arb_grant_wr, arb_grant_rd }),
+        .grantIdx()
+        );
+
+    assign host_to_afu_req.tvalid = arb_grant_wr || arb_grant_rd;
+    assign axi_mmio_if.awready = arb_grant_wr;
+    assign axi_mmio_if.wready = arb_grant_wr;
+    assign axi_mmio_if.arready = arb_grant_rd;
+
+    assign axi_mmio_if.bvalid = arb_grant_wr;
+    assign axi_mmio_if.b = '0;
+
+    always_comb
+    begin
+        host_to_afu_req.t = '0;
+        host_to_afu_req.t.data.is_write = arb_grant_wr;
+
+        if (arb_grant_rd)
+        begin
+            // The PCIe SS keeps reads simple. They are always assumed to be the
+            // full bus width and the address is aligned to a bus boundary.
+            host_to_afu_req.t.data.addr = axi_mmio_if.ar.addr;
+            host_to_afu_req.t.data.byte_count = 8;
+        end
+        else
+        begin
+            // The PCIe SS signals a 32 bit write with both strb and by setting
+            // addr[2]. The PIM expects data to always start at payload[0], since
+            // that matches TLP encoding.
+            host_to_afu_req.t.data.addr = axi_mmio_if.aw.addr;
+            host_to_afu_req.t.data.byte_count =
+                (axi_mmio_if.w.strb[0] && axi_mmio_if.w.strb[4]) ? 8 : 4;
+
+            host_to_afu_req.t.data.payload = { '0, axi_mmio_if.w.data };
+            if (!axi_mmio_if.w.strb[0])
+                host_to_afu_req.t.data.payload[31:0] = axi_mmio_if.w.data[63:32];
+        end
+    end
+
+    //
+    // Cross requests to the primary clock
+    //
+    ofs_plat_axi_mem_if_async_shim_channel
+      #(
+        .ADD_TIMING_REG_STAGES(0),
+        .ADD_TIMING_READY_STAGES(0),
+        .READY_FROM_ALMOST_FULL(0),
+        .N_ENTRIES(2),
+        .DATA_WIDTH($bits(host_mmio_req.t))
+        )
+      from_csr_clk
+       (
+        .clk_in(csr_clk),
+        .reset_n_in(csr_reset_n),
+        .ready_in(host_to_afu_req.tready),
+        .valid_in(host_to_afu_req.tvalid),
+        .data_in(host_to_afu_req.t),
+
+        .clk_out(clk),
+        .reset_n_out(reset_n),
+        .ready_out(host_mmio_req.tready),
+        .valid_out(host_mmio_req.tvalid),
+        .data_out(host_mmio_req.t)
+        );
+
+
+    //
+    // Read responses
+    //
+
+    // Cross back to the CSR clock
+    ofs_plat_axi_stream_if
+      #(
+        .TDATA_TYPE(t_gen_tx_mmio_afu_rsp),
+        .TUSER_TYPE(logic)
+        )
+      afu_to_host_rsp();
+
+    assign afu_to_host_rsp.clk = csr_clk;
+    assign afu_to_host_rsp.reset_n = csr_reset_n;
+    assign afu_to_host_rsp.instance_number = fiu_mmio_if.instance_number;
+
+    ofs_plat_axi_mem_if_async_shim_channel
+      #(
+        .ADD_TIMING_REG_STAGES(0),
+        .ADD_TIMING_READY_STAGES(0),
+        .READY_FROM_ALMOST_FULL(0),
+        .N_ENTRIES(2),
+        .DATA_WIDTH($bits(host_mmio_rsp.t))
+        )
+      to_csr_clk
+       (
+        .clk_in(clk),
+        .reset_n_in(reset_n),
+        .ready_in(host_mmio_rsp.tready),
+        .valid_in(host_mmio_rsp.tvalid),
+        .data_in(host_mmio_rsp.t),
+
+        .clk_out(csr_clk),
+        .reset_n_out(csr_reset_n),
+        .ready_out(afu_to_host_rsp.tready),
+        .valid_out(afu_to_host_rsp.tvalid),
+        .data_out(afu_to_host_rsp.t)
+        );
+
+    assign afu_to_host_rsp.tready = axi_mmio_if.rready;
+    assign axi_mmio_if.rvalid = afu_to_host_rsp.tvalid;
+    always_comb
+    begin
+        axi_mmio_if.r = '0;
+        axi_mmio_if.r.data = { '0, afu_to_host_rsp.t.data.payload };
+    end
+
+endmodule // ofs_plat_host_chan_@group@_gen_mmio_axi_lite

--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/ofs_plat_host_chan_mmio_wr_data.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/ofs_plat_host_chan_mmio_wr_data.sv
@@ -56,6 +56,7 @@ module ofs_plat_host_chan_mmio_wr_data_comb
     // just truncate the result and synthesis will drop the unused part.
     function automatic logic [511:0] replicate_chunks(
         logic [11:0] n_bytes,
+        logic [63:0] byte_addr,
         logic [511:0] d_in
         );
 
@@ -80,7 +81,7 @@ module ofs_plat_host_chan_mmio_wr_data_comb
     endfunction // mmio_replicate_chunks
 
     // Replicate small write data across the entire data width
-    assign payload_out = t_payload'(replicate_chunks(byte_count,
+    assign payload_out = t_payload'(replicate_chunks(byte_count, byte_addr,
                                                      { '0, payload_in }));
 
     // First stage of byte mask generation: generate a DWORD-level mask

--- a/plat_if_tests/host_chan_mmio/hw/rtl/axi/afu_axi.sv
+++ b/plat_if_tests/host_chan_mmio/hw/rtl/axi/afu_axi.sv
@@ -155,7 +155,13 @@ module afu
         if (mmio512_if.wvalid && mmio512_if.wready)
         begin
             mmio512_reg.wvalid <= 1'b1;
-            mmio512_reg.w <= mmio512_if.w;
+            mmio512_reg.w.user <= mmio512_if.w.user;
+            mmio512_reg.w.strb <= mmio512_if.w.strb;
+            for (int i = 0; i < 64; i = i + 1)
+            begin
+                if (mmio512_if.w.strb[i])
+                    mmio512_reg.w.data[i*8 +: 8] <= mmio512_if.w.data[i*8 +: 8];
+            end
         end
 
         // Consume new 64 bit write address
@@ -278,7 +284,9 @@ module afu
         { 32'h0,  // reserved
           16'(`OFS_PLAT_PARAM_CLOCKS_PCLK_FREQ),
           2'h0,	  // 64 bit read/write bus
-          10'h0,  // reserved
+          9'h0,  // reserved
+          // Will the AFU consume a 512 bit MMIO write?
+          1'(ofs_plat_host_chan_pkg::MMIO_512_WRITE_SUPPORTED),
           4'h1    // AXI MMIO interfaces
           };
 


### PR DESCRIPTION
- PIM maps MMIO traffic from the incoming AXI-Lite interface instead of from TLP.
- Add ASE support for ofs_plat_afu().
- Update host_chan_mmio test to indicate when 512 bit MMIO writes are not allowed. The current PCIe SS implementation drops writes larger than 64 bits.